### PR TITLE
Add node location support

### DIFF
--- a/src/riak_core_cluster_cli.erl
+++ b/src/riak_core_cluster_cli.erl
@@ -46,12 +46,14 @@ register_all_usage() ->
     clique:register_usage(["riak-admin", "cluster", "status"], status_usage()),
     clique:register_usage(["riak-admin", "cluster", "partition"], partition_usage()),
     clique:register_usage(["riak-admin", "cluster", "partitions"], partitions_usage()),
-    clique:register_usage(["riak-admin", "cluster", "partition_count"], partition_count_usage()).
+    clique:register_usage(["riak-admin", "cluster", "partition_count"], partition_count_usage()),
+    clique:register_usage(["riak-admin", "cluster", "location"], location_usage()),
+    clique:register_usage(["riak-admin", "cluster", "location", '*'], location_usage()).
 
 register_all_commands() ->
     lists:foreach(fun(Args) -> apply(clique, register_command, Args) end,
                   [status_register(), partition_count_register(),
-                   partitions_register(), partition_register()]).
+                   partitions_register(), partition_register(), location_register()]).
 
 %%%
 %% Cluster status
@@ -72,6 +74,7 @@ cluster_usage() ->
      "    partition        Map partition IDs to indexes\n",
      "    partitions       Display partitions on a node\n",
      "    partition-count  Display ring size or node partition count\n\n",
+     "    location         Set node location\n\n",
      "  Use --help after a sub-command for more details.\n"
     ].
 
@@ -111,12 +114,24 @@ status(_CmdBase, [], []) ->
     [T0,T1,Table,T2].
 
 format_status(Node, Status, Ring, RingStatus) ->
+    NodesLocations = riak_core_ring:get_nodes_locations(Ring),
+    format_status(Node, Status, Ring, RingStatus,
+                  has_location_set_in_cluster(NodesLocations), NodesLocations).
+
+format_status(Node, Status, Ring, RingStatus, false, _) ->
     {Claimant, _RingReady, Down, MarkedDown, Changes} = RingStatus,
     [{node, is_claimant(Node, Claimant)},
      {status, Status},
      {avail, node_availability(Node, Down, MarkedDown)},
      {ring, claim_percent(Ring, Node)},
-     {pending, future_claim_percentage(Changes, Ring, Node)}].
+     {pending, future_claim_percentage(Changes, Ring, Node)}];
+format_status(Node, Status, Ring, RingStatus, true, NodesLocations) ->
+    Row = format_status(Node, Status, Ring, RingStatus, false, NodesLocations),
+    Row ++ [{location, riak_core_location:get_node_location(Node, NodesLocations)}].
+
+-spec has_location_set_in_cluster(dict:dict()) -> boolean().
+has_location_set_in_cluster(NodesLocations) ->
+    0 =/= dict:size(NodesLocations).
 
 is_claimant(Node, Node) ->
     " (C) " ++ atom_to_list(Node) ++ " ";
@@ -262,6 +277,43 @@ id_out1(id, Id, Ring, RingSize) when Id < RingSize ->
     clique_status:table([[{index, Idx}, {id, Id}, {node, Owner}]]);
 id_out1(id, Id, _Ring, _RingSize) ->
     make_alert(["ERROR: Id ", integer_to_list(Id), " is invalid."]).
+
+%%%
+%% Location
+%%%
+location_usage() ->
+    ["riak-admin cluster location <new_location> [--node node]\n\n",
+     "  Set the node location parameter\n\n",
+     "Options\n",
+     "  -n <node>, --node <node>\n",
+     "      Set node location for the specified node.\n"
+    ].
+
+location_register() ->
+    [["riak-admin", "cluster", "location", '*'],  % Cmd
+     [], % KeySpecs
+     [{node, [{shortname, "n"}, {longname, "node"},
+              {typecast, fun clique_typecast:to_node/1}]}], % FlagSpecs
+      fun stage_set_location/3].                               % Implementation callback
+
+stage_set_location([_, _, _, Location], _, Flags) ->
+    Node = proplists:get_value(node, Flags, node()),
+    try
+      case riak_core_claimant:set_node_location(Node, Location) of
+        ok ->
+          [clique_status:text(
+            io_lib:format("Success: staged changing location of node ~p to ~s~n",
+                          [Node, Location]))];
+        {error, not_member} ->
+          make_alert(
+            io_lib:format("Failed: ~p is not a member of the cluster.~n", [Node])
+          )
+      end
+    catch
+      Exception:Reason ->
+        lager:error("Setting node location failed ~p:~p", [Exception, Reason]),
+        make_alert("Setting node location failed, see log for details~n")
+    end.
 
 %%%
 %% Internal

--- a/src/riak_core_console.erl
+++ b/src/riak_core_console.erl
@@ -649,7 +649,9 @@ print_plan(Changes, Ring, NextRings) ->
                       io:format("resize-ring    ~p to ~p partitions~n",[CurrentSize,NewRingSize]);
                  ({_, abort_resize}) ->
                       CurrentSize = riak_core_ring:num_partitions(Ring),
-                      io:format("resize-ring    abort. current size: ~p~n", [CurrentSize])
+                      io:format("resize-ring    abort. current size: ~p~n", [CurrentSize]);
+                 ({Node, {set_location, Location}}) ->
+                     io:format("set-location  ~p to ~s~n", [Node, Location])
               end, Changes),
     io:format("~79..-s~n", [""]),
     io:format("~n"),

--- a/src/riak_core_location.erl
+++ b/src/riak_core_location.erl
@@ -1,0 +1,47 @@
+%% -------------------------------------------------------------------
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_core_location).
+
+%% API
+-export([has_staged_location_change/1, clear_staged_locations/1,
+         get_node_location/2]).
+
+%% checking for staged location changes
+-spec has_staged_location_change(riak_core_ring:riak_core_ring()) -> boolean().
+has_staged_location_change(Ring) ->
+  Locations = dict:to_list(riak_core_ring:get_nodes_locations(Ring)),
+  [] =/= lists:filter(fun({_, {staged, _}}) -> true; (_) -> false end, Locations).
+
+-spec clear_staged_locations(riak_core_ring:riak_core_ring()) ->
+  riak_core:riak_core_ring().
+clear_staged_locations(ChStatge) ->
+  NodesLocations = riak_core_ring:get_nodes_locations(ChStatge),
+  dict:fold(fun(Node, {staged, Location}, Acc) ->
+                  riak_core_ring:set_node_location(Node, Location, Acc);
+               (_, _, Acc) ->
+                  Acc
+            end, ChStatge, NodesLocations).
+
+-spec get_node_location(node(), dict:dict()) -> binary() | unknown.
+get_node_location(Node, Locations) ->
+  case dict:find(Node, Locations) of
+    error ->
+      unknown;
+    {ok, Location} ->
+      Location
+  end.

--- a/src/riak_core_ring.erl
+++ b/src/riak_core_ring.erl
@@ -81,6 +81,8 @@
          set_member/4,
          set_member/5,
          members/2,
+         set_node_location/3,
+         get_nodes_locations/1,
          set_claimant/2,
          increment_vclock/2,
          ring_version/1,
@@ -906,6 +908,19 @@ pending_changes(State) ->
 
 set_pending_changes(State, Transfers) ->
     State?CHSTATE{next=Transfers}.
+
+-spec set_node_location(node(), binary() | {staged, binary()}, chstate()) ->
+  chstate().
+set_node_location(Node, Location, State) ->
+  NodesLocations = get_nodes_locations(State),
+  NewNodesLocations = dict:store(Node, Location, NodesLocations),
+  update_meta('$nodes_locations', NewNodesLocations, State).
+
+-spec get_nodes_locations(chstate()) -> dict:dict().
+get_nodes_locations(?CHSTATE{members=Members} = ChState) ->
+  {ok, Value} = get_meta('$nodes_locations', dict:new(), ChState),
+  Nodes = get_members(Members),
+  dict:filter(fun(Node, _) -> lists:member(Node, Nodes) end, Value).
 
 %% @doc Given a ring, `Resizing', that has been resized (and presumably rebalanced)
 %%      schedule a resize transition for `Orig'.


### PR DESCRIPTION
Location support for RIAK

Currently we are running a Riak cluster in different locations (you can also call it site or availability zone). 
The expectation is to be able to survive the loss of one entire site without any service interruption. The current  n_val is server_count-1, and the pw/pr is floor(n_val/2)+1. If we want to scale our Riak cluster for example double the cluster, we need to increase the n_val/pw/pr to meet the expectation.

Our idea is to be able to assemble a Riak ring where the neighbouring v_nodes are on different locations. This way we can reduce the replication factor to the number of locations + ~1 (to cover tail violations) which has the advantage that our data need less space, network load is reduced and we are able to scale our cluster without increasing the replication factor. 

In this pr location has been introduced. When claiming a new ring the list of nodes is ordered taking into consideration the location of the individual nodes, in a manner that to adjacent nodes are preferably from different locations. . 